### PR TITLE
Include plenary.nvim as dependency in recommended packer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ You need to have [ledger](https://github.com/ledger/ledger) installed.
 Add the package to your package manager.
 
 ```lua
-use 'piero-vic/cmp-ledger'
+use {
+    'piero-vic/cmp-ledger',
+    requires = "nvim-lua/plenary.nvim"
+}
 ```
 
 Setup the completion source.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the package to your package manager.
 ```lua
 use {
     'piero-vic/cmp-ledger',
-    requires = "nvim-lua/plenary.nvim"
+    requires = 'nvim-lua/plenary.nvim'
 }
 ```
 


### PR DESCRIPTION
After further investigation, the issue was simply a missing dependency. Closes #1.